### PR TITLE
api: support threefold login tokens

### DIFF
--- a/python/config.py.sample
+++ b/python/config.py.sample
@@ -118,8 +118,17 @@ config = {
     ##
     ## You also need to provide the appid, which is the host where
     ## the hub is hosted (which should be the same as public-website value
+    ##
+    ## In order to get API calls working, you need to specify a 32 bytes seed
+    ## used to produce signed tokens users can use to authenticate themself
+    ## on API requests. This 32 seed needs to remain private.
+    ##
+    ## You can generate the seed using python NaCl:
+    ##   from nacl import utils
+    ##   nacl.utils.random(32)
     'threebot-privatekey': '',
     'threebot-appid': 'hub.tld',
+    'threebot-seed': b'',
 
     ## When using authentication, there is also possible to hard code
     ## a 'guest' token, this token will be matched like an itsyou.online

--- a/python/config.py.sample
+++ b/python/config.py.sample
@@ -124,6 +124,7 @@ config = {
     ## on API requests. This 32 seed needs to remain private.
     ##
     ## You can generate the seed using python NaCl:
+    ##   import nacl
     ##   from nacl import utils
     ##   nacl.utils.random(32)
     'threebot-privatekey': '',

--- a/python/flist-uploader.py
+++ b/python/flist-uploader.py
@@ -79,7 +79,7 @@ if config['authentication']:
         '/_iyo_callback', None, True, True, 'organization', config['guest-token']
     )
 
-    hub.threebot.configure(app, config['threebot-appid'], config['threebot-privatekey'])
+    hub.threebot.configure(app, config['threebot-appid'], config['threebot-privatekey'], config['threebot-seed'])
 
 else:
     hub.itsyouonline.disabled(app)
@@ -231,9 +231,17 @@ def login_method():
     return internalRedirect("logins.html")
 
 @app.route('/login-iyo')
-@hub.itsyouonline.requires_auth()
+@hub.itsyouonline.force_login()
 def login_iyo():
     return internalRedirect("users.html")
+
+@app.route('/showtoken')
+def show_token():
+    token = request.args.get("key", None)
+    if token == None:
+        return abort(404)
+
+    return globalTemplate("token.html", {'token': token, "url": config['public-website']})
 
 @app.route('/upload', methods=['GET', 'POST'])
 @hub.security.protected()

--- a/python/flist-uploader.py
+++ b/python/flist-uploader.py
@@ -11,7 +11,6 @@ from stat import *
 from flask import Flask, Response, request, redirect, url_for, render_template, abort, make_response, send_from_directory, session
 from werkzeug.utils import secure_filename
 from werkzeug.middleware.proxy_fix import ProxyFix
-# from werkzeug.contrib.fixers import ProxyFix
 from werkzeug.wrappers import Request
 from config import config
 from hub.flist import HubPublicFlist, HubFlist
@@ -67,7 +66,6 @@ if not hc.check():
 # initialize flask application
 #
 app = Flask(__name__)
-# app.wsgi_app = hub.itsyouonline.ItsYouChecker(app.wsgi_app)
 app.wsgi_app = ProxyFix(app.wsgi_app)
 app.url_map.strict_slashes = False
 app.secret_key = os.urandom(24)

--- a/python/flist-uploader.py
+++ b/python/flist-uploader.py
@@ -235,12 +235,8 @@ def login_method():
 def login_iyo():
     return internalRedirect("users.html")
 
-@app.route('/showtoken')
-def show_token():
-    token = request.args.get("key", None)
-    if token == None:
-        return abort(404)
-
+@app.route('/token/<token>')
+def show_token(token):
     return globalTemplate("token.html", {'token': token, "url": config['public-website']})
 
 @app.route('/upload', methods=['GET', 'POST'])

--- a/python/flist-uploader.py
+++ b/python/flist-uploader.py
@@ -531,7 +531,7 @@ def api_readme(username, flist):
     return response
 
 @app.route('/api/flist/me', methods=['GET'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_myself():
     username = session['username']
 
@@ -539,7 +539,7 @@ def api_my_myself():
 
 
 @app.route('/api/flist/me/<flist>', methods=['GET', 'DELETE'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_inspect(flist):
     username = session['username']
 
@@ -549,21 +549,21 @@ def api_my_inspect(flist):
     return api_inspect(username, flist)
 
 @app.route('/api/flist/me/<source>/link/<linkname>', methods=['GET'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_symlink(source, linkname):
     username = session['username']
 
     return api_symlink(username, source, linkname)
 
 @app.route('/api/flist/me/<linkname>/crosslink/<repository>/<sourcename>', methods=['GET'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_crosssymlink(linkname, repository, sourcename):
     username = session['username']
 
     return api_cross_symlink(username, repository, sourcename, linkname)
 
 @app.route('/api/flist/me/<source>/rename/<destination>')
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_rename(source, destination):
     username = session['username']
     flist = HubPublicFlist(config, username, source)
@@ -580,14 +580,14 @@ def api_my_rename(source, destination):
     return api_response()
 
 @app.route('/api/flist/me/promote/<sourcerepo>/<sourcefile>/<localname>', methods=['GET'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_promote(sourcerepo, sourcefile, localname):
     username = session['username']
 
     return api_promote(username, sourcerepo, sourcefile, localname)
 
 @app.route('/api/flist/me/upload', methods=['POST'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_upload():
     username = session['username']
 
@@ -603,7 +603,7 @@ def api_my_upload():
         return api_response(response['message'], 500)
 
 @app.route('/api/flist/me/upload-flist', methods=['POST'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_upload_flist():
     username = session['username']
 
@@ -619,7 +619,7 @@ def api_my_upload_flist():
         return api_response(response['message'], 500)
 
 @app.route('/api/flist/me/merge/<target>', methods=['POST'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_merge(target):
     username = session['username']
 
@@ -638,7 +638,7 @@ def api_my_merge(target):
     return api_response()
 
 @app.route('/api/flist/me/docker', methods=['POST'])
-@hub.itsyouonline.requires_auth()
+@hub.security.apicall()
 def api_my_docker():
     username = session['username']
 

--- a/python/hub/security.py
+++ b/python/hub/security.py
@@ -1,8 +1,48 @@
-from flask import request, redirect, session
+from flask import request, redirect, session, current_app, jsonify
 from functools import wraps
 from config import config
 import hub.itsyouonline
 import hub.threebot
+
+def apicall():
+    def decorator(handler):
+        @wraps(handler)
+        def _wrapper(*args, **kwargs):
+            if not config['authentication']:
+                session['accounts'] = ['Administrator']
+                session['username'] = 'Administrator'
+                return handler(*args, **kwargs)
+
+            threebot = current_app.config['threebot_config']['auth']
+
+            if not request.headers.get("Authorization"):
+                return jsonify({"message": "no authorization provided", "status": "error"}), 401
+
+            # We won't have any dot in threebot base64 token
+            # if we have some dots in the token, it's the jwt from
+            # itsyou online
+            if "." in request.headers.get("Authorization"):
+                error, code = hub.itsyouonline.authenticate()
+
+                if code != 200:
+                    return error, code
+
+                return handler(*args, **kwargs)
+
+            # Let's authenticate using new threebot login
+            authorized, code = threebot.signed()
+
+            print("Authorized", authorized)
+
+            if code == 200:
+                session['accounts'] = [authorized]
+                session['username'] = authorized
+                return handler(*args, **kwargs)
+
+            return jsonify({"message": authorized, "status": "error"}), code
+
+        return _wrapper
+    return decorator
 
 def protected():
     def decorator(handler):
@@ -12,8 +52,6 @@ def protected():
                 session['accounts'] = ['Administrator']
                 session['username'] = 'Administrator'
                 return handler(*args, **kwargs)
-
-            print(session.get("authenticated"))
 
             if not session.get('authenticated'):
                 return redirect("/login-method")

--- a/python/hub/threebot.py
+++ b/python/hub/threebot.py
@@ -170,7 +170,7 @@ class ThreeBotAuthenticator:
             signed = self.signkey.sign(bpayload, nacl.encoding.Base64Encoder)
             hexsign = signed.decode('utf-8')
 
-            return redirect("/showtoken?key=%s" % hexsign, code=302)
+            return redirect("/token/%s" % hexsign, code=302)
 
         @self.app.route('/login')
         def login():

--- a/python/hub/threebot.py
+++ b/python/hub/threebot.py
@@ -53,7 +53,7 @@ class ThreeBotAuthenticator:
         print(token)
 
         try:
-            signed = self.signkey.verify_key.verify(token, None, nacl.encoding.Base64Encoder)
+            signed = self.signkey.verify_key.verify(token, None, nacl.encoding.URLSafeBase64Encoder)
             print(signed)
 
         except:
@@ -167,7 +167,7 @@ class ThreeBotAuthenticator:
             payload = [message, int(time.time())]
 
             bpayload = json.dumps(payload).encode()
-            signed = self.signkey.sign(bpayload, nacl.encoding.Base64Encoder)
+            signed = self.signkey.sign(bpayload, nacl.encoding.URLSafeBase64Encoder)
             hexsign = signed.decode('utf-8')
 
             return redirect("/token/%s" % hexsign, code=302)

--- a/python/templates/layout.html
+++ b/python/templates/layout.html
@@ -52,6 +52,8 @@
                     <li><a href="#" onclick="uswitch('{{ account }}')">{{ account }}</a></li>
                     {% endfor %}
                     <li role="separator" class="divider"></li>
+                    <li><a href="/token">Generate API Token</a></li>
+                    <li role="separator" class="divider"></li>
                     <li><a href="/logout">Logout</a></li>
                 </ul>
             </li>
@@ -65,6 +67,7 @@
                 <ul class="dropdown-menu">
                     <li><a href="/login">Login with ThreeFold Connect</a></li>
                     <li><a href="/login-iyo">Login with ItsYou.Online</a></li>
+                    <li><a href="/token">Generate API Token</a></li>
                 </ul>
 
                 </li>

--- a/python/templates/token.html
+++ b/python/templates/token.html
@@ -1,0 +1,17 @@
+{% extends "layout.html" %}
+{% block title %}Zero-OS Hub{% endblock %}
+
+{% block content %}
+<div class="jumbotron">
+    <div class="container">
+        <h1>API Token</h1>
+        <p>Your API Token is ready.</p>
+        <p>To submit API call, just use <code>Authorization: bearer [token]</code> when
+        sending requests.</p>
+        <pre>{{ token }}</pre>
+
+        <p>Here is <code>curl</code> example you can use to ensure your token is valid:</p>
+        <pre>curl -H "Authorization: bearer {{ token }}" {{ url }}/api/flist/me</pre>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Support threefold login app to authenticate and create token valid for api calls.

Internal changes:
- Each protected url now use `security` modules, this module does the selection between iyo and threebot.
- Still use `Authorization: bearer [token]` as authentication method, both supported and detected
- Generate a persistant token based on a single login via the app
- Generated token is signed by private key of the hub, and verified when used to ensure it's issued by the hub
- Add a new interface page to show token and example how to use it

Available for test: https://playground.hub.grid.tf/