### PR TITLE
modify file updated timestamp handling for symlinks and taglinks

### DIFF
--- a/src/static/js/hub.js
+++ b/src/static/js/hub.js
@@ -22,7 +22,7 @@ function repositories(source) {
 function flists_file(file, username, tagname) {
     var output = {
         'size': file['size'],
-        'updated': file['updated'],
+        'updated': (file['type'] == 'symlink' || file['type'] == 'taglink') && file['linktime'] ? file['linktime'] : file['updated'],
     };
 
     var fileicon = $('<span>', {'class': 'glyphicon glyphicon-file'});


### PR DESCRIPTION
## Description

On the `tf-autobuilder / v*` view page, the "Updated" column shows the timestamp of the target flist file instead of the link's own modification time for symlinks and taglinks. This causes confusion because:

- When a new build is made (which happens on each merge), the target flist's timestamp gets updated
- The link's timestamp in the UI updates even though the link itself wasn't modified
- For example, a tag link created on Nov 19 shows Nov 20 (the timestamp of the flist inside) instead of Nov 19 (when the link was actually created)
  <img width="1480" height="709" alt="image" src="https://github.com/user-attachments/assets/6d41083b-4171-4e23-8a59-7fa48143232c" />

## Solution

Modified the frontend to display `linktime` (the link's modification time) instead of `updated` (the target file's modification time) for symlinks and taglinks. 
